### PR TITLE
Gave middlewares intuitive names

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,14 +2,14 @@ module.exports = function(options) {
 
   if (options && options.setOnOldIE) {
 
-    return function(req, res, next) {
+    return function xXSSProtection$withOldIE(req, res, next) {
       res.setHeader('X-XSS-Protection', '1; mode=block');
       next();
     };
 
   } else {
 
-    return function(req, res, next) {
+    return function xXSSProtection$withoutOldIE(req, res, next) {
 
       var matches = /msie\s*(\d+)/i.exec(req.headers['user-agent']);
 

--- a/index.js
+++ b/index.js
@@ -2,14 +2,14 @@ module.exports = function(options) {
 
   if (options && options.setOnOldIE) {
 
-    return function xXSSProtection$withOldIE(req, res, next) {
+    return function xXssProtection(req, res, next) {
       res.setHeader('X-XSS-Protection', '1; mode=block');
       next();
     };
 
   } else {
 
-    return function xXSSProtection$withoutOldIE(req, res, next) {
+    return function xXssProtection(req, res, next) {
 
       var matches = /msie\s*(\d+)/i.exec(req.headers['user-agent']);
 


### PR DESCRIPTION
If you look into the express routing table you will find the names of the middleware functions. Before this change only `"<anonymous>"` was displayed.