### PR TITLE
Enable X-XSS-Protection header for IE versions prior to 8.0

### DIFF
--- a/index.js
+++ b/index.js
@@ -9,7 +9,7 @@ module.exports = function xXssProtection (options) {
       var matches = /msie\s*(\d+)/i.exec(req.headers['user-agent'])
 
       var value
-      if (!matches || (parseFloat(matches[1]) >= 9)) {
+      if (!matches || (parseFloat(matches[1]) !== 8)) {
         value = '1; mode=block'
       } else {
         value = '0'

--- a/test/disabled_browser_list.txt
+++ b/test/disabled_browser_list.txt
@@ -1,7 +1,2 @@
 Mozilla/5.0 (compatible; MSIE 8.0; Windows NT 5.2; Trident/4.0; Media Center PC 4.0; SLCC1; .NET CLR 3.0.04320)
 Mozilla/5.0 (compatible; MSIE 8.0; Windows NT 5.1; Trident/4.0; SLCC1; .NET CLR 3.0.4506.2152; .NET CLR 3.5.30729; .NET CLR 1.1.4322)
-Mozilla/5.0 (Windows; U; MSIE 7.0; Windows NT 5.2)
-Mozilla/5.0 (compatible; MSIE 7.0; Windows NT 6.0; en-US)
-Mozilla/4.0 (compatible; MSIE 6.1; Windows XP)
-Mozilla/5.0 (compatible; MSIE 6.0; Windows NT 5.1; SV1; .NET CLR 1.1.4325)
-Mozilla/5.0 (compatible; MSIE 6.0; Windows NT 5.1)

--- a/test/enabled_browser_list.txt
+++ b/test/enabled_browser_list.txt
@@ -4,6 +4,8 @@ Mozilla/5.0 (compatible; MSIE 10.0; Windows NT 6.1; WOW64; Trident/6.0)
 Mozilla/5.0 (compatible; MSIE 10.0; Windows NT 6.1; Trident/6.0)
 Mozilla/5.0 (compatible; MSIE 9.0; Windows NT 7.1; Trident/5.0)
 Mozilla/5.0 (compatible; MSIE 9.0; Windows NT 6.1; WOW64; Trident/5.0; SLCC2; Media Center PC 6.0; InfoPath.3; MS-RTC LM 8; Zune 4.7)
+Mozilla/5.0 (Windows; U; MSIE 7.0; Windows NT 5.2)
+Mozilla/5.0 (compatible; MSIE 7.0; Windows NT 6.0; en-US)
 Mozilla/5.0 (Windows NT 6.3; rv:36.0) Gecko/20100101 Firefox/36.0
 Mozilla/5.0 (Windows NT 6.1; rv:21.0) Gecko/20130401 Firefox/21.0
 Mozilla/5.0(Windows; U; Windows NT 7.0; rv:1.9.2) Gecko/20100101 Firefox/3.6


### PR DESCRIPTION
Enabling X-XSS-Protection for IE versions prior to 8.0 would not brake
anything, because this versions didn't supported this header, but it
prevents OWASP ZAP from raising warnigs. Unfortunately this tool makes
requests with user agent of IE 6.0.
